### PR TITLE
Add `--output` and `--assertions` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ unexpected = require('unexpected');
 unexpected.use(require('my-plugin'));
 ```
 
-I know this is anoying but we need to control which version of unexpected is
+I know this is annoying but we need to control which version of unexpected is
 used, and a peer dependency wont cut it.
 
 Then you update your npm scripts to require the bootstrap file:
@@ -38,6 +38,11 @@ Then you update your npm scripts to require the bootstrap file:
   "deploy-site": "deploy-site"
 },
 ```
+
+### Other options
+
+#### `--output <directory>`
+Changes the default output directory from `site-build`
 
 Now you are ready to add markdown files in a documentation directory. The
 subfolders `assertions` and `api` are special. In the `assertions`

--- a/index.js
+++ b/index.js
@@ -104,13 +104,19 @@ module.exports = function generate(options) {
 
         return result;
     }
+    
+    var assertionsPattern = null;
+    if (options.assertions) {
+        assertionsPattern = options.assertions;
+    }
+    var output = options.output || 'site-build';
 
     metalSmith('.')
-        .destination('site-build')
+        .destination(output)
         .source('documentation')
         .use(require('metalsmith-collections')({
             assertions: {
-                pattern: 'assertions/*/*.md'
+                pattern: assertionsPattern || 'assertions/*/*.md'
             },
             apiPages: {
                 pattern: 'api/*.md'
@@ -249,6 +255,6 @@ module.exports = function generate(options) {
         .use(require('./lib/delete-less-files')())
         .build(function (err) {
             if (err) { throw err; }
-            console.log('wrote site to site-build');
+            console.log('wrote site to ' + output);
         });
 };


### PR DESCRIPTION
`--output` changes the output directory from the default of `site-build`

`--assertions` changes the default pattern to look for assertion
documentation from `assertions/*/*.md`. This is left undocumented as it
is only for advanced usage

I need this as I need to do two separate runs of `generate-site`, and then merge the site afterwards. There's probably a nicer way, but this was the easiest I could see.