### PR TITLE
Avoid href=/ when issuing a relative link to the current page

### DIFF
--- a/templates/_api-menu.ejs
+++ b/templates/_api-menu.ejs
@@ -2,7 +2,7 @@
     <ul>
         <% collections.apiPages.forEach(function (apiPage) { %>
         <li class="<%= '/' + path + '/' === apiPage.url ? 'active' : '' %>">
-            <a href="<%= relative(apiPage.url) + '/' %>"><%= apiPage.title %></a>
+            <a href="<%= (relative(apiPage.url) || '.') + '/' %>"><%= apiPage.title %></a>
         </li>
         <% }) %>
     </ul>

--- a/templates/_assertions-menu.ejs
+++ b/templates/_assertions-menu.ejs
@@ -1,10 +1,10 @@
 <nav id="assertion-menu" class="sidebar js-remember-scroll-position">
     <% Object.keys(assertionsByType).forEach(function (type) { %>
-        <h3 class="<%= path === 'assertions/' + type ? 'active' : '' %>"><a href="<%= relative('/assertions/' + type + '/') + '/' %>"><%= type %></a></h3>
+        <h3 class="<%= path === 'assertions/' + type ? 'active' : '' %>"><a href="<%= (relative('/assertions/' + type + '/') || '.') + '/' %>"><%= type %></a></h3>
         <ul>
             <% assertionsByType[type].forEach(function (assertion) { %>
             <li class="<%= '/' + path + '/' === assertion.url ? 'active' : '' %>">
-                <a href="<%= relative(assertion.url) + '/' %>"><%= assertion.title %></a>
+                <a href="<%= (relative(assertion.url) || '.') + '/' %>"><%= assertion.title %></a>
             </li>
             <% }) %>
         </ul>

--- a/templates/_header.ejs
+++ b/templates/_header.ejs
@@ -8,7 +8,7 @@
     <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="<%= relative('/static/bug-icon-black.ico') %>">
     <title><%= windowTitle %></title>
 </head>
-<body class="sidebar-hidden<%=typeof hasSidebar !== 'undefined' ? ' has-sidebar' : ''%><%=typeof theme !== 'undefined' ? ' theme-' + theme : '' %>"> 
+<body class="sidebar-hidden<%=typeof hasSidebar !== 'undefined' ? ' has-sidebar' : ''%><%=typeof theme !== 'undefined' ? ' theme-' + theme : '' %>">
     <header>
         <div class="logo-icon"></div>
         <nav>
@@ -17,16 +17,16 @@
                     <button class="menu-toggle" onclick="toggleSidebar()"></button>
                 </li>
                 <% collections.pages.filter(function (page) { return page.url === '/' }).forEach(function (page) { %>
-                <li class="<%- path === '' ? 'active' : '' %>"><a href="<%= relative('/') + '/' %>"><%= page.title %></a></li>
+                <li class="<%- path === '' ? 'active' : '' %>"><a href="<%= (relative('/') || '.') + '/' %>"><%= page.title %></a></li>
                 <% }) %>
                 <% if (Object.keys(assertionsByType).length > 0) { %>
-                <li class="<%- path.match(/^assertions\/?/) ? 'active' : '' %>"><a href="<%= relative(assertionsByType[Object.keys(assertionsByType)[0]][0].url) + '/' %>">Assertions</a></li>
+                <li class="<%- path.match(/^assertions\/?/) ? 'active' : '' %>"><a href="<%= (relative(assertionsByType[Object.keys(assertionsByType)[0]][0].url) || '') + '/' %>">Assertions</a></li>
                 <% } %>
                 <% if (collections.apiPages.length > 0) { %>
-                <li class="<%- path.match(/^api\/?/) ? 'active' : '' %>"><a href="<%= relative(collections.apiPages[0].url) + '/' %>">API</a></li>
+                <li class="<%- path.match(/^api\/?/) ? 'active' : '' %>"><a href="<%= (relative(collections.apiPages[0].url) || '.') + '/' %>">API</a></li>
                 <% } %>
                 <% collections.pages.filter(function (page) { return page.url !== '/' }).forEach(function (page) { %>
-                <li class="<%- '/' + path + '/' === page.url ? 'active' : '' %>"><a href="<%= relative(page.url) + '/' %>"><%= page.title %></a></li>
+                <li class="<%- '/' + path + '/' === page.url ? 'active' : '' %>"><a href="<%= (relative(page.url) || '.') + '/' %>"><%= page.title %></a></li>
                 <% }) %>
             </ul>
         </nav>


### PR DESCRIPTION
The `relative` function returns the empty string when the target url is identical to that of the current page. In some cases we will naively append a `/` to that, which turns it into a root-relative link to the front page.

Pointed out by @Munter in the Unexpected gitter channel: https://gitter.im/unexpectedjs/unexpected?at=5c2cded4ab910e7d3a0f1fdb