### PR TITLE
Allow top-level menu pages to not generate a menu entry

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,6 +193,14 @@ module.exports = function generate(options) {
     .use(function(files, metalsmith, next) {
       var metadata = metalsmith.metadata();
 
+      metadata.collections.menuPages = metadata.collections.pages.filter(function (page) {
+        return page.url !== '/' && page.menuPage !== false;
+      });
+
+      metadata.collections.menuPages.forEach(function (page) {
+        page.collection.push('menuPages');
+      });
+
       metadata.collections.apiPages.sort(function(a, b) {
         var aTitle = a.title.toLowerCase();
         var bTitle = b.title.toLowerCase();

--- a/templates/_header.ejs
+++ b/templates/_header.ejs
@@ -25,7 +25,7 @@
                 <% if (collections.apiPages.length > 0) { %>
                 <li class="<%- path.match(/^api\/?/) ? 'active' : '' %>"><a href="<%= (relative(collections.apiPages[0].url) || '.') + '/' %>">API</a></li>
                 <% } %>
-                <% collections.pages.filter(function (page) { return page.url !== '/' }).forEach(function (page) { %>
+                <% collections.menuPages.forEach(function (page) { %>
                 <li class="<%- '/' + path + '/' === page.url ? 'active' : '' %>"><a href="<%= (relative(page.url) || '.') + '/' %>"><%= page.title %></a></li>
                 <% }) %>
             </ul>


### PR DESCRIPTION
You specify that in the metadata the following way:

menuPage: false