### PR TITLE
Allow overriding the contents of the assertion and API pages.

### DIFF
--- a/templates/_header.ejs
+++ b/templates/_header.ejs
@@ -19,12 +19,6 @@
                 <% collections.pages.filter(function (page) { return page.url === '/' }).forEach(function (page) { %>
                 <li class="<%- path === '' ? 'active' : '' %>"><a href="<%= (relative('/') || '.') + '/' %>"><%= page.title %></a></li>
                 <% }) %>
-                <% if (Object.keys(assertionsByType).length > 0) { %>
-                <li class="<%- path.match(/^assertions\/?/) ? 'active' : '' %>"><a href="<%= (relative(assertionsByType[Object.keys(assertionsByType)[0]][0].url) || '') + '/' %>">Assertions</a></li>
-                <% } %>
-                <% if (collections.apiPages.length > 0) { %>
-                <li class="<%- path.match(/^api\/?/) ? 'active' : '' %>"><a href="<%= (relative(collections.apiPages[0].url) || '.') + '/' %>">API</a></li>
-                <% } %>
                 <% collections.menuPages.forEach(function (page) { %>
                 <li class="<%- '/' + path + '/' === page.url ? 'active' : '' %>"><a href="<%= (relative(page.url) || '.') + '/' %>"><%= page.title %></a></li>
                 <% }) %>

--- a/templates/assertion.ejs
+++ b/templates/assertion.ejs
@@ -4,8 +4,8 @@
     <% include _assertions-menu.ejs %>
     <div class="main" tabindex="-1">
         <div class="content">
-            <h1><%= title %></h1>
             <% if (declarations.length > 0) { %>
+                <h1><%= title %></h1>
                 <ul class="declarations">
                 <% declarations.forEach(function (declaration) { %>
                     <li><%= declaration %></li>


### PR DESCRIPTION
This patch allows defining an "assertions.md" page that can be reached from the top-level "Assertions" link. In the absence of such a page it falls back to the old behaviour of creating a direct link to the first assertion. Note the support has been extended to "api.md" as well do we didn't have to return to this.

This is a pre-requisite for addressing: https://github.com/unexpectedjs/unexpected/issues/462