### PR TITLE
Allow overriding content of api and assertion top-level pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,17 +254,23 @@ module.exports = function generate(options) {
       });
       metadata.assertionsByType = assertionsByType;
 
-      metadata.assertionsUrl = metadata.collections.assertions.some(
-        page => page.url === '/assertions/'
-      )
-        ? '/assertions/'
-        : assertionsByType[Object.keys(assertionsByType)[0]][0].url;
+      metadata.assertionsUrl = null;
+      if (Object.keys(assertionsByType).length > 0) {
+        metadata.assertionsUrl = metadata.collections.assertions.some(
+          page => page.url === '/assertions/'
+        )
+          ? '/assertions/'
+          : assertionsByType[Object.keys(assertionsByType)[0]][0].url;
+      }
 
-      metadata.apiPagesUrl = metadata.collections.apiPages.some(
-        page => page.url === '/api/'
-      )
-        ? '/api/'
-        : metadata.collections.apiPages[0].url;
+      metadata.apiPagesUrl = null;
+      if (metadata.collections.apiPages.length > 0) {
+        metadata.apiPagesUrl = metadata.collections.apiPages.some(
+          page => page.url === '/api/'
+        )
+          ? '/api/'
+          : metadata.collections.apiPages[0].url;
+      }
 
       next();
     })

--- a/index.js
+++ b/index.js
@@ -120,7 +120,10 @@ module.exports = function generate(options) {
     return result;
   }
 
-  var assertionsPattern = options.assertions || 'assertions/*/*.md';
+  var assertionsPattern = options.assertions || [
+    'assertions/*/*.md',
+    'assertions.md'
+  ];
   var output = options.output || 'site-build';
 
   metalSmith('.')
@@ -132,10 +135,10 @@ module.exports = function generate(options) {
           pattern: assertionsPattern
         },
         apiPages: {
-          pattern: 'api/*.md'
+          pattern: ['api/*.md', 'api.md']
         },
         pages: {
-          pattern: '*.md'
+          pattern: ['*.md', '!assertions.md', '!api.md']
         }
       })
     )
@@ -151,34 +154,44 @@ module.exports = function generate(options) {
           return /\.md$/.test(file);
         })
         .forEach(function(file) {
-          var id = file.match(/([^/]+)\.md$/)[1];
-          var name = idToName(id);
-
-          if (!files[file].title) {
-            files[file].title = name;
-          }
+          const id = file.match(/([^/]+)\.md$/)[1];
+          const name = idToName(id);
 
           if (files[file].collection.indexOf('apiPages') !== -1) {
             files[file].template = 'api.ejs';
+
+            if (file === 'api.md') {
+              files[file].title = 'API';
+            }
           } else if (files[file].collection.indexOf('assertions') !== -1) {
-            var type = file.match(/^assertions\/([^/]+)/)[1];
-
-            files[file].declarations = _.uniq(
-              (expect.assertions[name] || [])
-                .filter(function(assertionRule) {
-                  return assertionRule.subject.type.name === type;
-                })
-                .map(function(assertionRule) {
-                  return assertionRule.declaration.replace(
-                    /<.*?>/,
-                    '<' + assertionRule.subject.type.name + '>'
-                  );
-                })
-            );
-
             files[file].template = 'assertion.ejs';
-            files[file].windowTitle = type + ' - ' + name;
-            files[file].type = type;
+            files[file].declarations = [];
+
+            if (file === 'assertions.md') {
+              files[file].title = 'Assertions';
+            } else {
+              const type = file.match(/^assertions\/([^/]+)/)[1];
+
+              files[file].declarations = _.uniq(
+                (expect.assertions[name] || [])
+                  .filter(function(assertionRule) {
+                    return assertionRule.subject.type.name === type;
+                  })
+                  .map(function(assertionRule) {
+                    return assertionRule.declaration.replace(
+                      /<.*?>/,
+                      '<' + assertionRule.subject.type.name + '>'
+                    );
+                  })
+              );
+
+              files[file].windowTitle = name + ' (' + type + ')';
+              files[file].type = type;
+            }
+          }
+
+          if (!files[file].title) {
+            files[file].title = name;
           }
 
           if (!files[file].windowTitle) {
@@ -218,9 +231,11 @@ module.exports = function generate(options) {
       // Make sure that the most important types are listed first and in this order:
       var assertionsByType = {};
       metadata.collections.assertions.forEach(function(assertion) {
-        assertionsByType[assertion.type] =
-          assertionsByType[assertion.type] || [];
-        assertionsByType[assertion.type].push(assertion);
+        if (assertion.type) {
+          assertionsByType[assertion.type] =
+            assertionsByType[assertion.type] || [];
+          assertionsByType[assertion.type].push(assertion);
+        }
       });
 
       assertionsByType = sortTypesByHierarchy(assertionsByType);
@@ -238,6 +253,19 @@ module.exports = function generate(options) {
         });
       });
       metadata.assertionsByType = assertionsByType;
+
+      metadata.assertionsUrl = metadata.collections.assertions.some(
+        page => page.url === '/assertions/'
+      )
+        ? '/assertions/'
+        : assertionsByType[Object.keys(assertionsByType)[0]][0].url;
+
+      metadata.apiPagesUrl = metadata.collections.apiPages.some(
+        page => page.url === '/api/'
+      )
+        ? '/api/'
+        : metadata.collections.apiPages[0].url;
+
       next();
     })
     .use(function(files, metalsmith, next) {
@@ -274,7 +302,7 @@ module.exports = function generate(options) {
 
       metadata.collections.assertions.forEach(function(assertion) {
         indexData.push({
-          label: assertion.title + ' (' + assertion.type + ')',
+          label: assertion.windowTitle,
           url: assertion.url
         });
       });

--- a/templates/_api-menu.ejs
+++ b/templates/_api-menu.ejs
@@ -1,6 +1,6 @@
 <nav id="api-menu" class="sidebar js-remember-scroll-position">
     <ul>
-        <% collections.apiPages.forEach(function (apiPage) { %>
+        <% collections.apiPages.filter(page => page.url !== '/api/').forEach((apiPage) => { %>
         <li class="<%= '/' + path + '/' === apiPage.url ? 'active' : '' %>">
             <a href="<%= (relative(apiPage.url) || '.') + '/' %>"><%= apiPage.title %></a>
         </li>

--- a/templates/_header.ejs
+++ b/templates/_header.ejs
@@ -20,10 +20,10 @@
                 <li class="<%- path === '' ? 'active' : '' %>"><a href="<%= (relative('/') || '.') + '/' %>"><%= page.title %></a></li>
                 <% }) %>
                 <% if (Object.keys(assertionsByType).length > 0) { %>
-                <li class="<%- path.match(/^assertions\/?/) ? 'active' : '' %>"><a href="<%= (relative(assertionsByType[Object.keys(assertionsByType)[0]][0].url) || '') + '/' %>">Assertions</a></li>
+                <li class="<%- path.match(/^assertions\/?/) ? 'active' : '' %>"><a href="<%= (relative(assertionsUrl) || '.') + '/' %>">Assertions</a></li>
                 <% } %>
                 <% if (collections.apiPages.length > 0) { %>
-                <li class="<%- path.match(/^api\/?/) ? 'active' : '' %>"><a href="<%= (relative(collections.apiPages[0].url) || '.') + '/' %>">API</a></li>
+                <li class="<%- path.match(/^api\/?/) ? 'active' : '' %>"><a href="<%= (relative(apiPagesUrl) || '.') + '/' %>">API</a></li>
                 <% } %>
                 <% collections.menuPages.forEach(function (page) { %>
                 <li class="<%- '/' + path + '/' === page.url ? 'active' : '' %>"><a href="<%= (relative(page.url) || '.') + '/' %>"><%= page.title %></a></li>

--- a/templates/_header.ejs
+++ b/templates/_header.ejs
@@ -19,10 +19,10 @@
                 <% collections.pages.filter(function (page) { return page.url === '/' }).forEach(function (page) { %>
                 <li class="<%- path === '' ? 'active' : '' %>"><a href="<%= (relative('/') || '.') + '/' %>"><%= page.title %></a></li>
                 <% }) %>
-                <% if (Object.keys(assertionsByType).length > 0) { %>
+                <% if (assertionsUrl) { %>
                 <li class="<%- path.match(/^assertions\/?/) ? 'active' : '' %>"><a href="<%= (relative(assertionsUrl) || '.') + '/' %>">Assertions</a></li>
                 <% } %>
-                <% if (collections.apiPages.length > 0) { %>
+                <% if (apiPagesUrl) { %>
                 <li class="<%- path.match(/^api\/?/) ? 'active' : '' %>"><a href="<%= (relative(apiPagesUrl) || '.') + '/' %>">API</a></li>
                 <% } %>
                 <% collections.menuPages.forEach(function (page) { %>

--- a/templates/assertion.ejs
+++ b/templates/assertion.ejs
@@ -4,8 +4,8 @@
     <% include _assertions-menu.ejs %>
     <div class="main" tabindex="-1">
         <div class="content">
-            <h1><%= title %></h1>
             <% if (declarations.length > 0) { %>
+                <h1><%= title %></h1>
                 <ul class="declarations">
                 <% declarations.forEach(function (declaration) { %>
                     <li><%= declaration %></li>


### PR DESCRIPTION
This patch allows defining an "assertions.md" page that can be reached from the top-level "Assertions" link. In the absence of such a page it falls back to the old behaviour of creating a direct link to the first assertion. Note the support has been extended to "api.md" as well do we didn't have to return to this.

This is a pre-requisite for addressing: https://github.com/unexpectedjs/unexpected/issues/462